### PR TITLE
fix responsiveness on project pages

### DIFF
--- a/components/HeaderWithImage.tsx
+++ b/components/HeaderWithImage.tsx
@@ -91,7 +91,7 @@ export const HeaderWithImage = (props: HeaderWithImageProps) => {
             {props.children}
             <Box
               sx={{
-                width: { md: '16rem', lg: '18rem' },
+                width: { md: '16rem', lg: '20rem' },
                 position: 'absolute',
                 right: { md: '2rem', lg: '0px' },
                 bottom: { md: '-4rem', lg: '-5rem' },

--- a/components/HeaderWithImage.tsx
+++ b/components/HeaderWithImage.tsx
@@ -5,21 +5,64 @@
 */
 import {
   Box,
+  Stack,
   useTheme,
 } from '@mui/material'
+import useMediaQuery from '@mui/material/useMediaQuery'
+
 import { ReactNode } from 'react'
 
 type HeaderWithImageProps = {
   imageSrc: string,
-  children: ReactNode // takes the JSX for header text 
+  children: ReactNode // takes the JSX for content that is put above/to left of image
 }
 
 export const HeaderWithImage = (props: HeaderWithImageProps) => {
   const theme = useTheme()
+  const extraSmallScreen = useMediaQuery(theme.breakpoints.down('md'))
 
-  return (
-    <>
-      {/* green section */}
+  return extraSmallScreen ?
+    // mobile design
+    (<>
+      <Box
+        sx={{
+          backgroundColor: theme.palette.primary.main,
+          width: '100%',
+          height: '30rem',
+          position: 'absolute',
+          zIndex: '0'
+        }}
+      ></Box>
+      <Stack
+        spacing="2rem"
+        sx={{
+          position: 'relative',
+          padding: '4rem 1rem 0rem 1rem',
+          color: theme.palette.primary.contrastText
+        }}
+      >
+        {props.children}
+        <Box sx={{
+          width: '75%',
+          margin: 'auto',
+          marginTop: '1rem',
+          aspectRatio: '1 / 1',
+          borderRadius: '20px',
+          boxShadow:
+            '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
+          backgroundColor: '#fff',
+          display: 'grid',
+          placeItems: 'center',
+          overflow: 'hidden'
+        }}>
+          <img
+            src={props.imageSrc}
+          />
+        </Box>
+      </Stack>
+    </>)
+    : // desktop design
+    (<>
       <Box
         sx={{
           backgroundColor: theme.palette.primary.main,
@@ -56,7 +99,6 @@ export const HeaderWithImage = (props: HeaderWithImageProps) => {
                 '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
               overflow: 'hidden',
               objectFit: 'cover'
-
             }}
           >
             <img
@@ -70,5 +112,6 @@ export const HeaderWithImage = (props: HeaderWithImageProps) => {
       </Box>
 
     </>
-  )
+    )
+
 }

--- a/components/HeaderWithImage.tsx
+++ b/components/HeaderWithImage.tsx
@@ -1,5 +1,6 @@
 /*
  * @2024 Digital Aid Seattle
+ *
  * Desktop design of page heading with square image, 
  * as seen on the individual project and event pages. 
 */
@@ -14,104 +15,111 @@ import { ReactNode } from 'react'
 
 type HeaderWithImageProps = {
   imageSrc: string,
-  children: ReactNode // takes the JSX for content that is put above/to left of image
+  children: ReactNode // takes the JSX for content that is put in the green section
 }
 
 export const HeaderWithImage = (props: HeaderWithImageProps) => {
   const theme = useTheme()
   const extraSmallScreen = useMediaQuery(theme.breakpoints.down('md'))
 
-  return extraSmallScreen ?
-    // mobile design
-    (<>
-      <Box
-        sx={{
-          backgroundColor: theme.palette.primary.main,
-          width: '100%',
-          height: '30rem',
-          position: 'absolute',
-          zIndex: '0'
-        }}
-      ></Box>
-      <Stack
-        spacing="2rem"
-        sx={{
-          position: 'relative',
-          padding: '4rem 1rem 0rem 1rem',
-          color: theme.palette.primary.contrastText
-        }}
-      >
-        {props.children}
-        <Box sx={{
-          width: '75%',
-          margin: 'auto',
-          marginTop: '1rem',
-          aspectRatio: '1 / 1',
-          borderRadius: '20px',
-          boxShadow:
-            '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
-          backgroundColor: '#fff',
-          display: 'grid',
-          placeItems: 'center',
-          overflow: 'hidden'
-        }}>
-          <img
-            src={props.imageSrc}
-          />
-        </Box>
-      </Stack>
-    </>)
-    : // desktop design
-    (<>
-      <Box
-        sx={{
-          backgroundColor: theme.palette.primary.main,
-          color: theme.palette.primary.contrastText,
-          width: '100%',
-        }}
-      >
-        {/* TODO: max-width of 880px is hardcoded throughout the site */}
-        <Box sx={{
-          maxWidth: '880px',
-          minHeight: '18rem',
-          margin: { md: '0', lg: '0 auto' },
-          display: 'flex',
-          alignItems: 'flex-end',
-          justifyContent: 'flex-start',
-          position: 'relative',
-          paddingY: '1rem',
-          paddingX: { md: '2rem', lg: 0 },
-        }}>
+  function MobileDesign() {
+    return (
+      <>
+        <Box
+          sx={{
+            backgroundColor: theme.palette.primary.main,
+            width: '100%',
+            height: '30rem',
+            position: 'absolute',
+            zIndex: '0'
+          }}
+        ></Box>
+        <Stack
+          spacing="2rem"
+          sx={{
+            position: 'relative',
+            padding: '4rem 1rem 0rem 1rem',
+            color: theme.palette.primary.contrastText
+          }}
+        >
           {props.children}
-          <Box
-            sx={{
-              width: { md: '16rem', lg: '18rem' },
-              position: 'absolute',
-              right: { md: '2rem', lg: '0px' },
-              bottom: { md: '-4rem', lg: '-5rem' },
-              zIndex: '2',
-              aspectRatio: '1/1',
-              backgroundColor: '#fff',
-              display: 'grid',
-              placeItems: 'center',
-              borderRadius: '20px',
-              boxShadow:
-                '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
-              overflow: 'hidden',
-              objectFit: 'cover'
-            }}
-          >
+          <Box sx={{
+            width: '75%',
+            margin: 'auto',
+            marginTop: '1rem',
+            aspectRatio: '1 / 1',
+            borderRadius: '20px',
+            boxShadow:
+              '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
+            backgroundColor: '#fff',
+            display: 'grid',
+            placeItems: 'center',
+            overflow: 'hidden'
+          }}>
             <img
               src={props.imageSrc}
-              style={{
-                width: '100%',
-              }}
+              style={{ width: '100%' }}
             />
           </Box>
-        </Box>
-      </Box>
-
-    </>
+        </Stack>
+      </>
     )
+  }
+
+  function DesktopDesign() {
+    return (
+      <>
+        <Box
+          sx={{
+            backgroundColor: theme.palette.primary.main,
+            color: theme.palette.primary.contrastText,
+            width: '100%',
+          }}
+        >
+          {/* TODO: max-width of 880px is hardcoded throughout the site */}
+          <Box sx={{
+            maxWidth: '880px',
+            minHeight: '18rem',
+            margin: { md: '0', lg: '0 auto' },
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'flex-start',
+            position: 'relative',
+            paddingY: '1rem',
+            paddingX: { md: '2rem', lg: 0 },
+          }}>
+            {props.children}
+            <Box
+              sx={{
+                width: { md: '16rem', lg: '18rem' },
+                position: 'absolute',
+                right: { md: '2rem', lg: '0px' },
+                bottom: { md: '-4rem', lg: '-5rem' },
+                zIndex: '2',
+                aspectRatio: '1/1',
+                backgroundColor: '#fff',
+                display: 'grid',
+                placeItems: 'center',
+                borderRadius: '20px',
+                boxShadow:
+                  '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
+                overflow: 'hidden',
+                objectFit: 'cover'
+              }}
+            >
+              <img
+                src={props.imageSrc}
+                style={{
+                  width: '100%',
+                }}
+              />
+            </Box>
+          </Box>
+        </Box>
+      </>
+    )
+  }
+
+  return extraSmallScreen ? <MobileDesign /> : <DesktopDesign />
 
 }

--- a/components/HeaderWithImage.tsx
+++ b/components/HeaderWithImage.tsx
@@ -74,13 +74,13 @@ export const HeaderWithImage = (props: HeaderWithImageProps) => {
         <Box sx={{
           maxWidth: '880px',
           minHeight: '18rem',
-          margin: '0 auto',
+          margin: { md: '0', lg: '0 auto' },
           display: 'flex',
           alignItems: 'flex-end',
           justifyContent: 'flex-start',
           position: 'relative',
           paddingY: '1rem',
-          paddingX: { md: '32px', lg: 0 },
+          paddingX: { md: '2rem', lg: 0 },
         }}>
           {props.children}
           <Box

--- a/components/HeaderWithImage.tsx
+++ b/components/HeaderWithImage.tsx
@@ -1,0 +1,74 @@
+/*
+ * @2024 Digital Aid Seattle
+ * Desktop design of page heading with square image, 
+ * as seen on the individual project and event pages. 
+*/
+import {
+  Box,
+  useTheme,
+} from '@mui/material'
+import { ReactNode } from 'react'
+
+type HeaderWithImageProps = {
+  imageSrc: string,
+  children: ReactNode // takes the JSX for header text 
+}
+
+export const HeaderWithImage = (props: HeaderWithImageProps) => {
+  const theme = useTheme()
+
+  return (
+    <>
+      {/* green section */}
+      <Box
+        sx={{
+          backgroundColor: theme.palette.primary.main,
+          color: theme.palette.primary.contrastText,
+          width: '100%',
+        }}
+      >
+        {/* TODO: max-width of 880px is hardcoded throughout the site */}
+        <Box sx={{
+          maxWidth: '880px',
+          minHeight: '18rem',
+          margin: '0 auto',
+          display: 'flex',
+          alignItems: 'flex-end',
+          justifyContent: 'flex-start',
+          position: 'relative',
+          paddingY: '1rem',
+          paddingX: { md: '32px', lg: 0 },
+        }}>
+          {props.children}
+          <Box
+            sx={{
+              width: { md: '16rem', lg: '18rem' },
+              position: 'absolute',
+              right: { md: '2rem', lg: '0px' },
+              bottom: { md: '-4rem', lg: '-5rem' },
+              zIndex: '2',
+              aspectRatio: '1/1',
+              backgroundColor: '#fff',
+              display: 'grid',
+              placeItems: 'center',
+              borderRadius: '20px',
+              boxShadow:
+                '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
+              overflow: 'hidden',
+              objectFit: 'cover'
+
+            }}
+          >
+            <img
+              src={props.imageSrc}
+              style={{
+                width: '100%',
+              }}
+            />
+          </Box>
+        </Box>
+      </Box>
+
+    </>
+  )
+}

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -167,8 +167,8 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             </Stack>
           }
           <Box sx={{
-            width: '50%',
-            margin: '0 auto',
+            width: '75%',
+            margin: 'auto',
             marginTop: '1rem',
             aspectRatio: '1 / 1',
             borderRadius: '20px',

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -190,10 +190,9 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
     )
   }
 
-  // new version wraps everything in a single box, so flow is maintained.
   function DesktopHeader() {
     return (
-      <Stack>
+      <>
         {/* green section */}
         <Box
           sx={{
@@ -205,7 +204,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
           {/* TODO: max-width of 880px is hardcoded throughout the site */}
           <Box sx={{
             maxWidth: '880px',
-            minHeight: '15rem',
+            minHeight: '18rem',
             margin: '0 auto',
             display: 'flex',
             alignItems: 'flex-end',
@@ -229,7 +228,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
                 width: { md: '16rem', lg: '18rem' },
                 position: 'absolute',
                 right: '2rem',
-                bottom: '-6rem',
+                bottom: { md: '-4rem', lg: '-5rem' },
                 zIndex: '2',
                 aspectRatio: '1/1',
                 backgroundColor: '#fff',
@@ -247,65 +246,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             </Box>
           </Box>
         </Box>
-      </Stack>
-    )
-  }
-
-  function DesktopHeaderOld() {
-    return (
-      <>
-        <Box
-          sx={{
-            backgroundColor: theme.palette.primary.main,
-            color: theme.palette.primary.contrastText,
-            paddingTop: '12rem',
-            paddingBottom: '1rem',
-            width: '100%',
-          }}
-        >
-          <Box
-            sx={{
-              position: 'relative',
-              margin: '0 auto',
-              maxWidth: '880px',
-              paddingX: { md: '2rem', lg: '0' },
-            }}
-          >
-            <Stack>
-              <Typography
-                variant={largeScreen ? 'displayLarge' : 'displayMedium'}
-                sx={{
-                  width: { md: '40vw', lg: '25rem' },
-                }}
-                component="h1"
-              >
-                {project.title}
-              </Typography>
-            </Stack>
-            <Box
-              sx={{
-                width: '18rem',
-                position: 'absolute',
-                right: '2rem',
-                bottom: '-6rem',
-                zIndex: '2',
-                aspectRatio: '1/1',
-                backgroundColor: '#fff',
-                display: 'grid',
-                placeItems: 'center',
-                borderRadius: '20px',
-                boxShadow:
-                  '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
-                overflow: 'hidden'
-              }}
-            >
-              <img
-                src={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
-              />
-            </Box>
-          </Box>
-        </Box>
-
+        {/* light section */}
         {!props.hideStatus &&
           <Box
             sx={{

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -260,7 +260,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
                 paddingLeft: { md: '2rem', lg: '0' },
               }}
             >
-              <Box marginBottom={'2rem'}>
+              <Box marginBottom={'2rem'} width='40vw'>
                 <BreadCrumbSection project={props.project} />
               </Box>
               <Stack direction="row" alignItems="center" spacing="1.5rem">

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -166,20 +166,23 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
               </Stack>
             </Stack>
           }
+          <Box sx={{
+            width: '50%',
+            margin: '0 auto',
+            marginTop: '1rem',
+            aspectRatio: '1 / 1',
+            borderRadius: '20px',
+            boxShadow:
+              '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
+            backgroundColor: '#fff',
+            display: 'grid',
+            placeItems: 'center',
+          }}>
+            <img
+              src={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
+            />
+          </Box>
 
-          <img
-            src={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
-            style={{
-              width: '50%',
-              margin: '0 auto',
-              marginTop: '1rem',
-              aspectRatio: '1 / 1',
-              display: 'block',
-              borderRadius: '20px',
-              boxShadow:
-                '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
-            }}
-          />
           <BreadCrumbSection project={props.project} />
         </Stack>
       </>
@@ -224,17 +227,17 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
                 right: { xs: '2rem', md: '2rem', lg: '2rem' },
                 bottom: '-6rem',
                 zIndex: '2',
+                aspectRatio: '1/1',
+                backgroundColor: '#fff',
+                display: 'grid',
+                placeItems: 'center',
+                borderRadius: '20px',
+                boxShadow:
+                  '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
               }}
             >
               <img
                 src={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
-                style={{
-                  width: '100%',
-                  display: 'block',
-                  borderRadius: '20px',
-                  boxShadow:
-                    '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
-                }}
               />
             </Box>
           </Box>

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -40,6 +40,7 @@ import Markdown from 'react-markdown'
 import { NavigateNextSharp } from '@mui/icons-material'
 import Link from 'next/link'
 import ProjectImage from '../assets/project-image.png'
+import { HeaderWithImage } from './HeaderWithImage'
 
 const PROJECT_IMAGE = ProjectImage.src;
 
@@ -194,58 +195,17 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
     return (
       <>
         {/* green section */}
-        <Box
-          sx={{
-            backgroundColor: theme.palette.primary.main,
-            color: theme.palette.primary.contrastText,
-            width: '100%',
-          }}
-        >
-          {/* TODO: max-width of 880px is hardcoded throughout the site */}
-          <Box sx={{
-            maxWidth: '880px',
-            minHeight: '18rem',
-            margin: '0 auto',
-            display: 'flex',
-            alignItems: 'flex-end',
-            justifyContent: 'flex-start',
-            position: 'relative',
-            paddingY: '1rem',
-            paddingX: { md: '32px', lg: 0 },
-
-          }}>
-            <Typography
-              variant={largeScreen ? 'displayLarge' : 'displayMedium'}
-              sx={{
-                width: { md: '40vw', lg: '35vw' },
-              }}
-              component="h1"
-            >
-              {project.title}
-            </Typography>
-            <Box
-              sx={{
-                width: { md: '16rem', lg: '18rem' },
-                position: 'absolute',
-                right: '2rem',
-                bottom: { md: '-4rem', lg: '-5rem' },
-                zIndex: '2',
-                aspectRatio: '1/1',
-                backgroundColor: '#fff',
-                display: 'grid',
-                placeItems: 'center',
-                borderRadius: '20px',
-                boxShadow:
-                  '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
-                overflow: 'hidden'
-              }}
-            >
-              <img
-                src={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
-              />
-            </Box>
-          </Box>
-        </Box>
+        <HeaderWithImage imageSrc={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}>
+          <Typography
+            variant={largeScreen ? 'displayLarge' : 'displayMedium'}
+            sx={{
+              width: { md: '40vw', lg: '35vw' },
+            }}
+            component="h1"
+          >
+            {project.title}
+          </Typography>
+        </HeaderWithImage>
         {/* light section */}
         {!props.hideStatus &&
           <Box

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -200,12 +200,9 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             backgroundColor: theme.palette.primary.main,
             color: theme.palette.primary.contrastText,
             width: '100%',
-            paddingX: { md: '32px', lg: 0 },
-            // paddingTop: '5rem',
-            paddingBottom: '1rem',
           }}
         >
-          {/* is there a way to wrap the content in a container? instead of hardcoding the width */}
+          {/* TODO: max-width of 880px is hardcoded throughout the site */}
           <Box sx={{
             maxWidth: '880px',
             minHeight: '15rem',
@@ -214,11 +211,14 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             alignItems: 'flex-end',
             justifyContent: 'flex-start',
             position: 'relative',
+            paddingY: '1rem',
+            paddingX: { md: '32px', lg: 0 },
+
           }}>
             <Typography
               variant={largeScreen ? 'displayLarge' : 'displayMedium'}
               sx={{
-                width: '40vw',
+                width: { md: '40vw', lg: '35vw' },
               }}
               component="h1"
             >
@@ -226,7 +226,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             </Typography>
             <Box
               sx={{
-                width: '18rem',
+                width: { md: '16rem', lg: '18rem' },
                 position: 'absolute',
                 right: '2rem',
                 bottom: '-6rem',
@@ -246,8 +246,6 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
               />
             </Box>
           </Box>
-
-
         </Box>
       </Stack>
     )

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -177,6 +177,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             backgroundColor: '#fff',
             display: 'grid',
             placeItems: 'center',
+            overflow: 'hidden'
           }}>
             <img
               src={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
@@ -234,6 +235,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
                 borderRadius: '20px',
                 boxShadow:
                   '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
+                overflow: 'hidden'
               }}
             >
               <img

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -196,7 +196,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
           sx={{
             backgroundColor: theme.palette.primary.main,
             color: theme.palette.primary.contrastText,
-            paddingTop: { md: '5.5rem', lg: '14.5rem' },
+            paddingTop: '12rem',
             paddingBottom: '1rem',
             width: '100%',
           }}
@@ -206,7 +206,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
               position: 'relative',
               margin: '0 auto',
               maxWidth: '880px',
-              paddingX: { xs: '1rem', md: '2rem', lg: '0' },
+              paddingX: { md: '2rem', lg: '0' },
             }}
           >
             <Stack>
@@ -222,7 +222,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             </Stack>
             <Box
               sx={{
-                width: { md: '14rem', lg: '18rem' },
+                width: '18rem',
                 position: 'absolute',
                 right: '2rem',
                 bottom: '-6rem',

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -134,28 +134,10 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
   function MobileHeader() {
     return (
       <>
-        <Box
-          sx={{
-            backgroundColor: theme.palette.primary.main,
-            width: '100%',
-            height: '30rem',
-            position: 'absolute',
-            zIndex: '0'
-          }}
-        ></Box>
-        <Stack
-          spacing="2rem"
-          sx={{
-            position: 'relative',
-            padding: '4rem 1rem 0rem 1rem',
-            color: theme.palette.primary.contrastText
-          }}
-        >
-          <Stack>
-            <Typography variant="displayMedium" component="h1">
-              {project.title}
-            </Typography>
-          </Stack>
+        <HeaderWithImage imageSrc={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}>
+          <Typography variant="displayMedium" component="h1">
+            {project.title}
+          </Typography>
           {!props.hideStatus &&
             <Stack spacing="1rem">
               <Stack direction="row" alignItems="center" spacing="1.5rem">
@@ -167,26 +149,15 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
               </Stack>
             </Stack>
           }
-          <Box sx={{
-            width: '75%',
-            margin: 'auto',
-            marginTop: '1rem',
-            aspectRatio: '1 / 1',
-            borderRadius: '20px',
-            boxShadow:
-              '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
-            backgroundColor: '#fff',
-            display: 'grid',
-            placeItems: 'center',
-            overflow: 'hidden'
-          }}>
-            <img
-              src={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
-            />
-          </Box>
-
+        </HeaderWithImage>
+        {/* content below image */}
+        <Box
+          sx={{
+            padding: '2rem 1rem 0rem 1rem',
+          }}
+        >
           <BreadCrumbSection project={props.project} />
-        </Stack>
+        </Box>
       </>
     )
   }
@@ -194,7 +165,6 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
   function DesktopHeader() {
     return (
       <>
-        {/* green section */}
         <HeaderWithImage imageSrc={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}>
           <Typography
             variant={largeScreen ? 'displayLarge' : 'displayMedium'}
@@ -206,7 +176,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             {project.title}
           </Typography>
         </HeaderWithImage>
-        {/* light section */}
+        {/* content below image */}
         {!props.hideStatus &&
           <Box
             sx={{

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -190,7 +190,70 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
     )
   }
 
+  // new version wraps everything in a single box, so flow is maintained.
   function DesktopHeader() {
+    return (
+      <Stack>
+        {/* green section */}
+        <Box
+          sx={{
+            backgroundColor: theme.palette.primary.main,
+            color: theme.palette.primary.contrastText,
+            width: '100%',
+            paddingX: { md: '32px', lg: 0 },
+            // paddingTop: '5rem',
+            paddingBottom: '1rem',
+          }}
+        >
+          {/* is there a way to wrap the content in a container? instead of hardcoding the width */}
+          <Box sx={{
+            maxWidth: '880px',
+            minHeight: '15rem',
+            margin: '0 auto',
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'flex-start',
+            position: 'relative',
+          }}>
+            <Typography
+              variant={largeScreen ? 'displayLarge' : 'displayMedium'}
+              sx={{
+                width: '40vw',
+              }}
+              component="h1"
+            >
+              {project.title}
+            </Typography>
+            <Box
+              sx={{
+                width: '18rem',
+                position: 'absolute',
+                right: '2rem',
+                bottom: '-6rem',
+                zIndex: '2',
+                aspectRatio: '1/1',
+                backgroundColor: '#fff',
+                display: 'grid',
+                placeItems: 'center',
+                borderRadius: '20px',
+                boxShadow:
+                  '0px 4px 8px 0px rgba(52, 61, 62, 0.08), 0px 8px 16px 0px rgba(52, 61, 62, 0.08)',
+                overflow: 'hidden'
+              }}
+            >
+              <img
+                src={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
+              />
+            </Box>
+          </Box>
+
+
+        </Box>
+      </Stack>
+    )
+  }
+
+  function DesktopHeaderOld() {
     return (
       <>
         <Box

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -222,9 +222,9 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             </Stack>
             <Box
               sx={{
-                width: { md: 'min(40vw, 18rem)', lg: 'min(40vw, 18rem)' },
+                width: { md: '14rem', lg: '18rem' },
                 position: 'absolute',
-                right: { xs: '2rem', md: '2rem', lg: '2rem' },
+                right: '2rem',
                 bottom: '-6rem',
                 zIndex: '2',
                 aspectRatio: '1/1',

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -134,6 +134,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
   function MobileHeader() {
     return (
       <>
+        {/* green section */}
         <HeaderWithImage imageSrc={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}>
           <Typography variant="displayMedium" component="h1">
             {project.title}
@@ -150,7 +151,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             </Stack>
           }
         </HeaderWithImage>
-        {/* content below image */}
+        {/* light section */}
         <Box
           sx={{
             padding: '2rem 1rem 0rem 1rem',
@@ -165,6 +166,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
   function DesktopHeader() {
     return (
       <>
+        {/* green section */}
         <HeaderWithImage imageSrc={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}>
           <Typography
             variant={largeScreen ? 'displayLarge' : 'displayMedium'}
@@ -176,37 +178,37 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
             {project.title}
           </Typography>
         </HeaderWithImage>
-        {/* content below image */}
-        {!props.hideStatus &&
-          <Box
+        {/* light section */}
+        <Box
+          sx={{
+            backgroundColor: theme.palette.background.default,
+            width: '100%',
+            paddingY: '1rem',
+          }}
+        >
+          <Stack
+            spacing="1rem"
+            width={{ md: 'auto', lg: '880px' }}
             sx={{
-              backgroundColor: theme.palette.background.default,
-              width: '100%',
-              paddingY: '1rem',
+              color: theme.palette.primary.main,
+              margin: '0 auto',
+              paddingLeft: { md: '2rem', lg: '0' },
             }}
           >
-            <Stack
-              spacing="1rem"
-              width={{ md: 'auto', lg: '880px' }}
-              sx={{
-                color: theme.palette.primary.main,
-                margin: '0 auto',
-                paddingLeft: { md: '2rem', lg: '0' },
-              }}
-            >
-              <Box marginBottom={'2rem'} width='40vw'>
-                <BreadCrumbSection project={props.project} />
-              </Box>
+            <Box marginBottom={'2rem'} width='40vw'>
+              <BreadCrumbSection project={props.project} />
+            </Box>
+            {!props.hideStatus && <>
               <Stack direction="row" alignItems="center" spacing="1.5rem">
                 <Typography variant="labelLarge">{project.programAreas.join(', ')}</Typography>
               </Stack>
               <Stack direction="row" alignItems="center" spacing="1.5rem">
                 <Typography variant="labelLarge">Project Status:</Typography>
                 <StateBadge state={project.status} />
-              </Stack>
-            </Stack>
-          </Box>
-        }
+              </Stack></>}
+          </Stack>
+        </Box>
+
       </>
     )
   }

--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -48,31 +48,32 @@ const CardProject = ({ project }: CardProjectProps) => {
             justifyContent: 'space-between',
           }}
         >
-          <Stack direction={{ xs: 'row', lg: 'column' }} gap="1.5rem">
+          <Stack direction={{ xs: 'row', lg: 'column' }} gap='1.5rem'>
             <CardMedia
-              component="img"
+              component='img'
               image={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
               sx={{
-                objectFit: "contain",
+                objectFit: 'contain',
                 width: { md: '7rem', lg: '100%' },
                 aspectRatio: '1 / 1',
                 borderRadius: '8px',
                 display: { xs: 'none', md: 'block' },
+                backgroundColor: 'white',
               }}
             />
-            <Stack spacing="1rem" sx={{ width: '100%' }}>
-              <Typography variant="titleLarge" component="h2">
+            <Stack spacing='1rem' sx={{ width: '100%' }}>
+              <Typography variant='titleLarge' component='h2'>
                 {project.title}
               </Typography>
-              <Stack spacing="1rem">
+              <Stack spacing='1rem'>
                 <Stack
-                  direction="row"
-                  justifyContent="space-between"
-                  alignItems="center"
+                  direction='row'
+                  justifyContent='space-between'
+                  alignItems='center'
                 >
                   {project.programAreas &&
-                    <Stack direction="row" justifyContent="space-between">
-                      <Typography variant="labelLarge">
+                    <Stack direction='row' justifyContent='space-between'>
+                      <Typography variant='labelLarge'>
                         {ProjectLabels.project_label + project.painpoint}
                       </Typography>
                     </Stack>
@@ -80,8 +81,8 @@ const CardProject = ({ project }: CardProjectProps) => {
                   <StateBadge state={project.status} />
                 </Stack>
                 {project.programAreas &&
-                  <Stack direction="row" justifyContent="space-between">
-                    <Typography variant="labelMedium">
+                  <Stack direction='row' justifyContent='space-between'>
+                    <Typography variant='labelMedium'>
                       {project.programAreas.join(', ')}
                     </Typography>
                   </Stack>
@@ -91,13 +92,13 @@ const CardProject = ({ project }: CardProjectProps) => {
           </Stack>
           <Typography
             sx={{
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              display: "-webkit-box",
-              WebkitLineClamp: "4",
-              WebkitBoxOrient: "vertical"
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: '-webkit-box',
+              WebkitLineClamp: '4',
+              WebkitBoxOrient: 'vertical'
             }}
-            variant="bodyMedium" >{project.description}</Typography>
+            variant='bodyMedium' >{project.description}</Typography>
         </CardContent>
       </CardActionArea>
     </Card>

--- a/pages/event.tsx
+++ b/pages/event.tsx
@@ -133,7 +133,7 @@ const HeaderSection = (props: { event: OSEvent }) => {
               position: 'relative',
               margin: '0 auto',
               maxWidth: '880px',
-              paddingX: { xs: '1rem', md: '2rem', lg: '0' },
+              paddingX: { md: '2rem', lg: '0' },
             }}>
             <Stack>
               <Typography
@@ -183,7 +183,7 @@ const HeaderSection = (props: { event: OSEvent }) => {
             width: '100%',
             paddingY: '1rem',
             margin: '0 auto',
-            paddingX: { xs: '1rem', md: '2rem', lg: '0' },
+            paddingX: { md: '2rem', lg: '0' },
           }}
         >
           <Stack

--- a/pages/event.tsx
+++ b/pages/event.tsx
@@ -123,7 +123,7 @@ const HeaderSection = (props: { event: OSEvent }) => {
           sx={{
             backgroundColor: theme.palette.primary.main,
             color: theme.palette.primary.contrastText,
-            paddingTop: { md: '5.5rem', lg: '14.5rem' },
+            paddingTop: { md: '5.5rem', lg: '12rem' },
             paddingBottom: '1rem',
             width: '100%',
           }}
@@ -182,15 +182,16 @@ const HeaderSection = (props: { event: OSEvent }) => {
             backgroundColor: theme.palette.background.default,
             width: '100%',
             paddingY: '1rem',
+            margin: '0 auto',
+            paddingX: { xs: '1rem', md: '2rem', lg: '0' },
           }}
         >
           <Stack
             spacing="1rem"
-            width={{ md: 'auto', lg: '880px' }}
+            width={{ md: '40vw', lg: '880px' }}
             sx={{
               color: theme.palette.primary.main,
-              margin: '0 auto',
-              paddingLeft: { md: '2rem', lg: '0' },
+              margin: { md: '0', lg: '0 auto' },
             }}
           >
             <BreadCrumbSection event={props.event} />

--- a/pages/event.tsx
+++ b/pages/event.tsx
@@ -68,29 +68,10 @@ const HeaderSection = (props: { event: OSEvent }) => {
       </Breadcrumbs>
     )
   }
-
   function MobileSection() {
     return (
-      <Box sx={{
-        backgroundColor: theme.palette.background.default
-      }}>
-        <Box
-          sx={{
-            backgroundColor: theme.palette.primary.main,
-            width: '100%',
-            height: '28.75rem',
-            position: 'absolute',
-            zIndex: '0',
-          }}
-        ></Box>
-        <Stack
-          spacing="2rem"
-          sx={{
-            position: 'relative',
-            padding: '4rem 1rem 0rem 1rem',
-            color: theme.palette.primary.contrastText,
-          }}
-        >
+      <>
+        <HeaderWithImage imageSrc={props.event.image && props.event.image.asset ? urlForImage(props.event.image).url() : DEFAULT_IMAGE}>
           <Stack>
             <Typography variant="headlineMedium" component="h2">
               Event
@@ -102,21 +83,16 @@ const HeaderSection = (props: { event: OSEvent }) => {
               {props.event.date}
             </Typography>
           </Stack>
-
-          {props.event.image && props.event.image.asset && <img
-            src={urlForImage(props.event.image).url()}
-            style={{
-              width: '100%',
-              aspectRatio: '1 / 1',
-              display: 'block'
-            }}
-          />
-          }
-          <Stack spacing="1rem">
-            <BreadCrumbSection event={props.event} />
-          </Stack>
-        </Stack>
-      </Box>
+        </HeaderWithImage>
+        {/* light section */}
+        <Box
+          sx={{
+            padding: '2rem 1rem 0rem 1rem',
+          }}
+        >
+          <BreadCrumbSection event={props.event} />
+        </Box>
+      </>
     )
   }
 
@@ -148,7 +124,6 @@ const HeaderSection = (props: { event: OSEvent }) => {
 
         <Box
           sx={{
-            backgroundColor: theme.palette.background.default,
             width: '100%',
             paddingY: '1rem',
             margin: '0 auto',
@@ -349,26 +324,29 @@ const EventPage = () => {
   }, [setLoading, router])
 
   return (
-    <>
-      <BlockComponent block={!event}>
-        {event &&
-          <>
+    <BlockComponent block={!event}>
+      {event &&
+        <>
+          <Box
+            sx={{
+              backgroundColor: theme.palette.background.default
+            }}>
             <HeaderSection event={event} />
-            <SectionContainer backgroundColor={theme.palette.background.default}>
-              <Stack
-                gap={{ xs: '1rem', lg: '2rem' }}
-                maxWidth="880px"
-                margin="0 auto" >
-                <InfoSection event={event} />
-                <AboutSection event={event} />
-                <ActivitySection event={event} />
-              </Stack>
-            </SectionContainer>
-            {event.rsvpLink && <ContactUsSection event={event} />}
-          </>
-        }
-      </BlockComponent>
-    </>
+          </Box>
+          <SectionContainer backgroundColor={theme.palette.background.default}>
+            <Stack
+              gap={{ xs: '1rem', lg: '2rem' }}
+              maxWidth="880px"
+              margin="0 auto" >
+              <InfoSection event={event} />
+              <AboutSection event={event} />
+              <ActivitySection event={event} />
+            </Stack>
+          </SectionContainer>
+          {event.rsvpLink && <ContactUsSection event={event} />}
+        </>
+      }
+    </BlockComponent>
   )
 }
 

--- a/pages/event.tsx
+++ b/pages/event.tsx
@@ -31,7 +31,11 @@ import Markdown from 'react-markdown';
 import { OSEvent } from 'types';
 import { eventsService } from './api/EventsService';
 import { useRouter } from 'next/navigation';
+import { HeaderWithImage } from 'components/HeaderWithImage';
 /*********/
+
+import ProjectImage from '../assets/project-image.png'
+const DEFAULT_IMAGE = ProjectImage.src;
 
 const Labels = {
   contact: 'Interested in this event?',
@@ -119,63 +123,28 @@ const HeaderSection = (props: { event: OSEvent }) => {
   function DesktopSection() {
     return (
       <>
-        <Box
-          sx={{
-            backgroundColor: theme.palette.primary.main,
-            color: theme.palette.primary.contrastText,
-            paddingTop: { md: '5.5rem', lg: '12rem' },
-            paddingBottom: '1rem',
-            width: '100%',
-          }}
-        >
-          <Box
-            sx={{
-              position: 'relative',
-              margin: '0 auto',
-              maxWidth: '880px',
-              paddingX: { md: '2rem', lg: '0' },
-            }}>
-            <Stack>
-              <Typography
-                variant={largeScreen ? 'headlineLarge' : 'headlineMedium'}
-                component="h2" >
-                Event
-              </Typography>
-              <Typography
-                variant={largeScreen ? 'displayLarge' : 'displayMedium'}
-                sx={{
-                  width: { md: '40vw', lg: '25rem' },
-                }}
-                component="h1" >
-                {props.event.title}
-              </Typography>
-              <Typography
-                variant={largeScreen ? 'headlineLarge' : 'headlineMedium'}
-                component="h2" >
-                {props.event.date}
-              </Typography>
-            </Stack>
-
-            {props.event.image && props.event.image.asset &&
-              <Box
-                sx={{
-                  width: { md: 'min(40vw, 18rem)', lg: '25rem' },
-                  position: 'absolute',
-                  right: { xs: '1rem', md: '2rem', lg: '0' },
-                  bottom: '-6rem',
-                  zIndex: '2',
-                }}
-              >
-                <img
-                  src={urlForImage(props.event.image).url()}
-                  style={{
-                    width: '100%',
-                    display: 'block'
-                  }} />
-              </Box>
-            }
-          </Box>
-        </Box>
+        <HeaderWithImage imageSrc={props.event.image && props.event.image.asset ? urlForImage(props.event.image).url() : DEFAULT_IMAGE}>
+          <Stack>
+            <Typography
+              variant={largeScreen ? 'headlineLarge' : 'headlineMedium'}
+              component="h2" >
+              Event
+            </Typography>
+            <Typography
+              variant={largeScreen ? 'displayLarge' : 'displayMedium'}
+              sx={{
+                width: { md: '40vw', lg: '25rem' },
+              }}
+              component="h1" >
+              {props.event.title}
+            </Typography>
+            <Typography
+              variant={largeScreen ? 'headlineLarge' : 'headlineMedium'}
+              component="h2" >
+              {props.event.date}
+            </Typography>
+          </Stack>
+        </HeaderWithImage>
 
         <Box
           sx={{


### PR DESCRIPTION
## What

> Summary of what you're changing.
- Non-square logos will be centered in a white container.
- No more overlapping of elements on smaller screen sizes.
- More consistency in the heading section height--only expands as needed.

## Why Do

> The motivation behind your change.
- Responsiveness
- Layout is more resilient: can handle long titles and different logo sizes without looking ugly.

## How Do

> Implementation choices, reviewer notes, caveats, etc.
- `DesktopHeader` now has a min height, instead of its size being determined only with vertical padding from its children. This means that the heading area will only grow as needed, which gets rid of the large amount of extra space that was above the multi-line titles. See screenshots!
- Since the single event and project pages have that same green heading with the square image, I put that in a component called `HeaderWithImage`. 

## Show Me

> Screenshot of your change, if applicable.

Before:
![image](https://github.com/digitalaidseattle/digital-aid-seattle-website/assets/60805050/08b93a1a-e28c-4a18-87c7-468562bce27b)

After:
![image](https://github.com/digitalaidseattle/digital-aid-seattle-website/assets/60805050/a51717a9-c842-426c-85b5-d37fabc21124)

Before (image overlaps breadcrumbs):
![image](https://github.com/digitalaidseattle/digital-aid-seattle-website/assets/60805050/bbd73be1-0b6d-4ebf-9768-81269c5b16e3)

After:
![image](https://github.com/digitalaidseattle/digital-aid-seattle-website/assets/60805050/8a13100d-68e6-45be-94d0-6e09abfcaf13)


