### PR TITLE
accessibility fixes

### DIFF
--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -90,7 +90,7 @@ const CommonHeader = () => {
               aria-label="page-info"
               aria-controls="menu-appbar"
               aria-haspopup="true"
-              onClick={()=>setShowMobileMenu(!showMobileMenu)}
+              onClick={() => setShowMobileMenu(!showMobileMenu)}
               sx={{ color: theme.palette.primary.contrastText }}
             >
               {showMobileMenu ? <CloseIcon /> : <MenuIcon />}
@@ -120,27 +120,27 @@ const CommonHeader = () => {
             <nav>
               <ul>
                 {Object.keys(SECTION_TO_PATH).map((name) => (
-                  <Button
-                    key={name}
-                    variant="contained"
-                    color={isCurrent(name)
-                      ? 'success'
-                      : 'primary'}
-                    disableRipple={true}
+                  <Link
+                    sx={{
+                      color: theme.palette.primary.contrastText,
+                      textUnderlineOffset: '0.5rem',
+                      textDecoration: isCurrent(name)
+                        ? 'underline'
+                        : 'none'
+                    }}
+                    href={SECTION_TO_PATH[name]}
                   >
-                    <Link
-                      sx={{
-                        color: theme.palette.primary.contrastText,
-                        textUnderlineOffset: '0.5rem',
-                        textDecoration: isCurrent(name)
-                          ? 'underline'
-                          : 'none'
-                      }}
-                      href={SECTION_TO_PATH[name]}
+                    <Button
+                      key={name}
+                      variant="contained"
+                      color={isCurrent(name)
+                        ? 'success'
+                        : 'primary'}
+                      disableRipple={true}
                     >
                       {name}
-                    </Link>
-                  </Button>
+                    </Button>
+                  </Link>
                 ))}
               </ul>
             </nav>
@@ -149,8 +149,8 @@ const CommonHeader = () => {
       </AppBar>
       {/* mobile slide-out menu */}
       {smallScreen &&
-      <Box sx={{ position: 'relative', zIndex: -1 }}>
-        <MobileMenu yTranslate={showMobileMenu ? '0' : '-500px'}> 
+        <Box sx={{ position: 'relative', zIndex: -1 }}>
+          <MobileMenu yTranslate={showMobileMenu ? '0' : '-500px'}>
             {Object.keys(SECTION_TO_PATH).map((name) => (
               <MenuItem
                 key={name}
@@ -170,7 +170,7 @@ const CommonHeader = () => {
               </MenuItem>
             ))}
           </MobileMenu>
-      </Box>}
+        </Box>}
     </Box>
   )
 }

--- a/components/HeaderWithImage.tsx
+++ b/components/HeaderWithImage.tsx
@@ -15,10 +15,15 @@ import { ReactNode } from 'react'
 
 type HeaderWithImageProps = {
   imageSrc: string,
+  imageAlt?: string,
   children: ReactNode // takes the JSX for content that is put in the green section
 }
 
-export const HeaderWithImage = (props: HeaderWithImageProps) => {
+export const HeaderWithImage = ({
+  imageSrc,
+  imageAlt = "",
+  children
+}: HeaderWithImageProps) => {
   const theme = useTheme()
   const extraSmallScreen = useMediaQuery(theme.breakpoints.down('md'))
 
@@ -42,7 +47,7 @@ export const HeaderWithImage = (props: HeaderWithImageProps) => {
             color: theme.palette.primary.contrastText
           }}
         >
-          {props.children}
+          {children}
           <Box sx={{
             width: '75%',
             margin: 'auto',
@@ -57,7 +62,8 @@ export const HeaderWithImage = (props: HeaderWithImageProps) => {
             overflow: 'hidden'
           }}>
             <img
-              src={props.imageSrc}
+              src={imageSrc}
+              alt={imageAlt}
               style={{ width: '100%' }}
             />
           </Box>
@@ -88,7 +94,7 @@ export const HeaderWithImage = (props: HeaderWithImageProps) => {
             paddingY: '1rem',
             paddingX: { md: '2rem', lg: 0 },
           }}>
-            {props.children}
+            {children}
             <Box
               sx={{
                 width: { md: '16rem', lg: '20rem' },
@@ -108,7 +114,8 @@ export const HeaderWithImage = (props: HeaderWithImageProps) => {
               }}
             >
               <img
-                src={props.imageSrc}
+                src={imageSrc}
+                alt={imageAlt}
                 style={{
                   width: '100%',
                 }}

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -345,6 +345,7 @@ const ProjectTeamSection = (props: { title: string, members?: TeamMember[] }) =>
               title={person.name}
               description={person.role}
               image={url}
+              alt={`headshot of ${person.name}`}
             />
           })}
         </Box>

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -145,7 +145,7 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
                 <Typography variant="labelLarge">{project.programAreas.join(', ')}</Typography>
               </Stack>
               <Stack direction="row" alignItems="center" spacing="1.5rem">
-                <Typography variant="labelLarge">{ProjectLabels.project_status}</Typography>
+                <Typography variant="labelLarge" >{ProjectLabels.project_status}</Typography>
                 <StateBadge state={project.status} />
               </Stack>
             </Stack>

--- a/components/ProjectComponents.tsx
+++ b/components/ProjectComponents.tsx
@@ -167,7 +167,9 @@ const ProjectHeaderSection = (props: { project: DASProject, hideStatus?: boolean
     return (
       <>
         {/* green section */}
-        <HeaderWithImage imageSrc={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}>
+        <HeaderWithImage
+          imageSrc={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
+          imageAlt={project.title + " logo"}>
           <Typography
             variant={largeScreen ? 'displayLarge' : 'displayMedium'}
             sx={{

--- a/components/RolesSection.tsx
+++ b/components/RolesSection.tsx
@@ -149,16 +149,16 @@ const RoleListing = ({
 const RoleContainer = ({ children }) => {
   return (
     <Box
-    sx={{
-      display: 'grid',
-      gridAutoFlow: 'columns',
-      gridTemplateColumns: { xs: 'repeat(1), minmax(15rem, 1fr)', md: `repeat(2, minmax(15rem, 1fr))`, lg: 'repeat(3, minmax(15rem, 1fr))' },
-      justifyContent: 'center',
-      gap: { xs: '1rem', md: '2rem' },
-      width: '100%',
-    }}
-  >
-    {children}
+      sx={{
+        display: 'grid',
+        gridAutoFlow: 'columns',
+        gridTemplateColumns: { xs: 'repeat(1), minmax(15rem, 1fr)', md: `repeat(2, minmax(15rem, 1fr))`, lg: 'repeat(3, minmax(15rem, 1fr))' },
+        justifyContent: 'center',
+        gap: { xs: '1rem', md: '2rem' },
+        width: '100%',
+      }}
+    >
+      {children}
     </Box>
   )
 }
@@ -167,23 +167,23 @@ const FilterableRoles = ({ roles, showLink }) => {
   const [activeFilters, setActiveFilters] = useState([]);
   const [rolesToDisplay, setRolesToDisplay] = useState([]);
   const [categories, setCategories] = useState([]);
- 
+
   useEffect(() => {
     setRolesToDisplay([...roles]);
     // using a set to build a list of categories that occur in roles data
     const uniqueCategories = new Set()
     roles.forEach(r => r.category && r.category.forEach(c => uniqueCategories.add(c)))
     setCategories(Array.from(uniqueCategories))
-  }, [roles]); 
+  }, [roles]);
 
   function filterRolesByCategory(selectedCategory) {
     // if a category is already active (the chip is checked)
     if (activeFilters.includes(selectedCategory)) {
       // remove the category from the list of active filters
-      let updatedFilters = activeFilters.filter(f=>f!==selectedCategory)
+      let updatedFilters = activeFilters.filter(f => f !== selectedCategory)
 
       // filter the roles to include only the ones in the new list of active filters
-      setRolesToDisplay(rolesToDisplay.filter(r=>r.category && r.category.some(c => updatedFilters.includes(c))))
+      setRolesToDisplay(rolesToDisplay.filter(r => r.category && r.category.some(c => updatedFilters.includes(c))))
       setActiveFilters(updatedFilters)
 
     } else { // the chip was unchecked at time of clicking on it
@@ -204,52 +204,52 @@ const FilterableRoles = ({ roles, showLink }) => {
   }
 
   return (
-      <>
-        <Stack direction="row" gap="1.5rem" marginBottom="3rem" sx={{flexWrap: 'wrap', justifyContent: 'center'}}>
-          {categories.map((category)=><Chip key={category} label={category} variant={activeFilters.includes(category) ? "filled" : "outlined"} icon={activeFilters.includes(category) && <Check/>} onClick={()=>filterRolesByCategory(category) }/>)}
-        </Stack>
-        <RoleContainer>
-            {activeFilters.length ? rolesToDisplay.map((singleRole, i) => (
-              <RoleListing
-                key={i}
-                index={i}
-                role={singleRole}
-                showLink={showLink} />
-            ))
-            : roles.map((singleRole, i) => (
-              <RoleListing
-                key={i}
-                index={i}
-                role={singleRole}
-                showLink={showLink} />
-            ))
-            }
-          </RoleContainer>
-        </>
-  )
-}
-
-const RolesOnly = ({ roles, showLink }) => {
-  return (
+    <>
+      <Stack aria-label="filter openings by skill area" direction="row" gap="1.5rem" marginBottom="3rem" sx={{ flexWrap: 'wrap', justifyContent: 'center' }}>
+        {categories.map((category) => <Chip key={category} label={category} variant={activeFilters.includes(category) ? "filled" : "outlined"} icon={activeFilters.includes(category) && <Check />} onClick={() => filterRolesByCategory(category)} />)}
+      </Stack>
       <RoleContainer>
-        {roles.map((singleRole, i) => (
+        {activeFilters.length ? rolesToDisplay.map((singleRole, i) => (
           <RoleListing
             key={i}
             index={i}
             role={singleRole}
             showLink={showLink} />
         ))
+          : roles.map((singleRole, i) => (
+            <RoleListing
+              key={i}
+              index={i}
+              role={singleRole}
+              showLink={showLink} />
+          ))
         }
       </RoleContainer>
+    </>
   )
 }
 
-const RolesSection = ({ title, showLink = false, roles = [], showFilters = false, children }: RolesSectionProps) => {  
+const RolesOnly = ({ roles, showLink }) => {
+  return (
+    <RoleContainer>
+      {roles.map((singleRole, i) => (
+        <RoleListing
+          key={i}
+          index={i}
+          role={singleRole}
+          showLink={showLink} />
+      ))
+      }
+    </RoleContainer>
+  )
+}
+
+const RolesSection = ({ title, showLink = false, roles = [], showFilters = false, children }: RolesSectionProps) => {
   return (
     roles.length > 0 && (
       <Section>
         <Subheader variant="headlineMedium">{title}</Subheader>
-        {showFilters ? <FilterableRoles roles={roles} showLink={showLink}/> : <RolesOnly roles={roles} showLink={showLink}/>
+        {showFilters ? <FilterableRoles roles={roles} showLink={showLink} /> : <RolesOnly roles={roles} showLink={showLink} />
         }
         {children}
       </Section>

--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -38,6 +38,7 @@ const CardProject = ({ project }: CardProjectProps) => {
         sx={{
           height: '100%',
         }}
+        aria-label={`navigate to project page for ${project.title}`}
       >
         <CardContent
           sx={{
@@ -99,7 +100,7 @@ const CardProject = ({ project }: CardProjectProps) => {
               WebkitLineClamp: '4',
               WebkitBoxOrient: 'vertical'
             }}
-            variant='bodyMedium' >{project.description}</Typography>
+            variant='bodyMedium'>{project.description}</Typography>
         </CardContent>
       </CardActionArea>
     </Card>

--- a/components/cards/CardProject.tsx
+++ b/components/cards/CardProject.tsx
@@ -52,6 +52,7 @@ const CardProject = ({ project }: CardProjectProps) => {
             <CardMedia
               component='img'
               image={project.imageSrc ? project.imageSrc : PROJECT_IMAGE}
+              alt={project.title + " logo"}
               sx={{
                 objectFit: 'contain',
                 width: { md: '7rem', lg: '100%' },

--- a/components/cards/CardWithPhoto.tsx
+++ b/components/cards/CardWithPhoto.tsx
@@ -4,12 +4,13 @@ import CardMedia from '@mui/material/CardMedia'
 import { useTheme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import { Box } from '@mui/material'
+
 type CardWithPhotoProps = {
   title: string
   description: string
   image: string
   imageWidth?: number
+  alt?: string
 }
 
 const CardWithPhoto = ({
@@ -17,6 +18,7 @@ const CardWithPhoto = ({
   description,
   image,
   imageWidth = 196,
+  alt = ""
 }: CardWithPhotoProps) => {
   const theme = useTheme()
   const isViewportSmall = useMediaQuery(theme.breakpoints.down('md'))
@@ -35,7 +37,9 @@ const CardWithPhoto = ({
             minWidth: imageWidth,
             aspectRatio: '1/1',
           }}
+          component="img"
           image={image}
+          alt={alt}
         />
       )}
       <CardContent

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -86,7 +86,7 @@ const ProjectsPage = () => {
             }}
             maxWidth={'880px'}
           >
-            <Stack direction="row" gap="1.5rem" marginBottom="3rem" sx={{ flexWrap: 'wrap', justifyContent: 'center' }}>
+            <Stack aria-label="filter projects by status" direction="row" gap="1.5rem" marginBottom="3rem" sx={{ flexWrap: 'wrap', justifyContent: 'center' }}>
               {dasProjectsService.filteredStatuses.map((status) =>
                 <Chip key={status} label={StatusLabels[status]}
                   variant={filterStatuses.includes(status) ? "filled" : "outlined"}


### PR DESCRIPTION
## What

> Summary of what you're changing.

- Alt tags added to images 
  - headshots are announced as "headshot of [name]"
  - logos announced as "logo of [partner]" 
- Aria labels make elements and navigation more clearer
  - It is clear to screenreader users that project cards navigate to a page about the project
  - Groups of filtering buttons are labelled as such

## Why Do

> The motivation behind your change.

Make site easier to navigate for screen readers.

## How Do

> Implementation choices, reviewer notes, caveats, etc.

Documenting unresolved issues (screenreader testing)
- Voiceover doesn't indicate the checked status of a filter.
- Most DOM elements are announced as "clickable", in Firefox. This happens when an element is given an event listener of any kind. Interestingly this does not happen in Chrome.
