### PR TITLE
add feature flag to support page

### DIFF
--- a/pages/support_us.tsx
+++ b/pages/support_us.tsx
@@ -3,9 +3,9 @@
  */
 import { Typography, useTheme } from '@mui/material'
 import { withBasicLayout } from 'components/layouts'
+import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { useFeature } from './api/FeatureService'
-import { useRouter } from 'next/router'
 
 const SupportUsPage = () => {
   const theme = useTheme()
@@ -17,7 +17,7 @@ const SupportUsPage = () => {
       console.error(`Support Us feature not implemented.`);
       router.push('/404')
     }
-  }, [supportUs])
+  }, [supportUs, router])
 
   return (
     <>

--- a/pages/support_us.tsx
+++ b/pages/support_us.tsx
@@ -1,8 +1,23 @@
+/*
+ * @2024 Digital Aid Seattle
+ */
 import { Typography, useTheme } from '@mui/material'
 import { withBasicLayout } from 'components/layouts'
+import { useEffect } from 'react'
+import { useFeature } from './api/FeatureService'
+import { useRouter } from 'next/router'
 
 const SupportUsPage = () => {
   const theme = useTheme()
+  const { data: supportUs } = useFeature('support-us');
+  const router = useRouter();
+
+  useEffect(() => {
+    if (supportUs !== undefined && supportUs === false) {
+      console.error(`Support Us feature not implemented.`);
+      router.push('/404')
+    }
+  }, [supportUs])
 
   return (
     <>


### PR DESCRIPTION
## What

> Provided a reroute when the feature flag is disabled.

## Why Do

> To prevent user from viewing the support us page if the feature is disabled.

