### PR TITLE
add dark overlay when menu is toggled

### DIFF
--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -85,14 +85,14 @@ const CommonHeader = () => {
             }}
           >
             {/* Hamburger menu when the screen is small. */}
-            <LogoBox/>
+            <LogoBox />
             <IconButton
               size="large"
               aria-hidden="true"
               onClick={() => setShowMobileMenu(!showMobileMenu)}
               sx={{ color: theme.palette.primary.contrastText }}
             >
-              {showMobileMenu ? <CloseIcon/> : <MenuIcon/>}
+              {showMobileMenu ? <CloseIcon /> : <MenuIcon />}
             </IconButton>
           </Box>
           {/* Menu items that are shown on desktop */}
@@ -106,7 +106,7 @@ const CommonHeader = () => {
               padding: '1.25rem 2.5rem !important',
             }}
           >
-            <LogoBox/>
+            <LogoBox />
             <nav>
               <ul>
                 {Object.keys(SECTION_TO_PATH).map((name) => (
@@ -161,6 +161,17 @@ const CommonHeader = () => {
               ))}
             </MobileMenu>
           </Box>}
+        {/* dark overlay */}
+        {showMobileMenu &&
+          <Box
+            sx={{
+              width: '100%',
+              height: '100vh',
+              background: 'rgba(0,0,0,0.6)',
+              position: 'absolute',
+              zIndex: '-2'
+            }}
+          ></Box>}
       </AppBar>
     </Box>
   )

--- a/components/CommonHeader.tsx
+++ b/components/CommonHeader.tsx
@@ -162,7 +162,7 @@ const CommonHeader = () => {
             </MobileMenu>
           </Box>}
         {/* dark overlay */}
-        {showMobileMenu &&
+        {showMobileMenu && smallScreen &&
           <Box
             sx={{
               width: '100%',


### PR DESCRIPTION
## What

> Summary of what you're changing.

- minor fix, where a dark overlay div appears under the mobile menu when toggled.

## Why Do

> The motivation behind your change.

- to address usability feedback, which was to prevent misclicks when interacting with menu.

## Show Me

> Screenshot of your change, if applicable.

![image](https://github.com/user-attachments/assets/dca13b18-5ed9-425f-bea1-0f83c03e91f8)