### PR TITLE
fix common footer

### DIFF
--- a/components/email-form/EmailFormContainer.tsx
+++ b/components/email-form/EmailFormContainer.tsx
@@ -34,7 +34,6 @@ const LabelSection = () => {
 const InputSection = () => {
   const theme = useTheme();
 
-  const { data: newsLetter } = useFeature('newsletter')
   const [email, setEmail] = useState('');
   const [subscribeMessage, setSubscribeMessage] = useState('');
   const [error, setError] = useState('');
@@ -55,7 +54,7 @@ const InputSection = () => {
     }
   }
 
-  return (newsLetter &&
+  return (
     <Stack
       sx={{
         flexDirection: { xs: 'column', md: 'row', lg: 'row' },
@@ -115,8 +114,11 @@ const InputSection = () => {
     </Stack>
   )
 }
+
 const EmailFormContainer = () => {
-  return (
+  const { data: newsLetter } = useFeature('newsletter')
+
+  return (newsLetter &&
     <Stack
       sx={{
         paddingTop: { md: '5rem', lg: '5rem' },


### PR DESCRIPTION
## What

> The label for the newsletter signup was being displayed

## Why Do

> looks bad otherwise


## Show Me

before:


<img width="684" alt="Screenshot 2024-10-30 at 11 19 16 AM" src="https://github.com/user-attachments/assets/d37ef339-7e1a-4219-9f3c-089277f7ad86">

after:

<img width="810" alt="Screenshot 2024-10-30 at 11 20 22 AM" src="https://github.com/user-attachments/assets/825ccc97-0989-44a5-965b-d7582e0f4c1b">
